### PR TITLE
Fix to allow compatibility with Windows Systems

### DIFF
--- a/edibles_dr5/check_extraction_results.py
+++ b/edibles_dr5/check_extraction_results.py
@@ -74,7 +74,13 @@ def plot_product(spec_dir, star_name, obs_date, plt_color, use_mask=False):
     spec_list = [item for item in spec_list if star_name in item.name]
 
     if isinstance(obs_date, str):
-        spec_list = [item for item in spec_list if obs_date in item.name]
+        temp_list = [item for item in spec_list if obs_date in item.name] # checks if obs_date is in the filename
+        if len(temp_list) == 0:
+            print("0 spectra found for this date")
+            obs_date = obs_date.replace(':', '_') # needed for Windows file naming compatibility
+            spec_list = [item for item in spec_list if obs_date in item.name]
+        else:
+            spec_list = [item for item in spec_list if obs_date in item.name] # the original obs_date check -- for linux systems
 
     if len(spec_list) == 0:
         return False

--- a/edibles_dr5/check_extraction_results.py
+++ b/edibles_dr5/check_extraction_results.py
@@ -76,7 +76,6 @@ def plot_product(spec_dir, star_name, obs_date, plt_color, use_mask=False):
     if isinstance(obs_date, str):
         temp_list = [item for item in spec_list if obs_date in item.name] # checks if obs_date is in the filename
         if len(temp_list) == 0:
-            print("0 spectra found for this date")
             obs_date = obs_date.replace(':', '_') # needed for Windows file naming compatibility
             spec_list = [item for item in spec_list if obs_date in item.name]
         else:


### PR DESCRIPTION
The check_extraction_results.py script has been modified to check if the file naming scheme contains either ':' or '_', this difference allows the CSV file obs_dates to still be used on a Windows system that does not allow the ':' character in file names.